### PR TITLE
126 turbo jobs

### DIFF
--- a/etc/bionano/aws/cloudformation/lambda-autoscaling/src/package.json
+++ b/etc/bionano/aws/cloudformation/lambda-autoscaling/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccc-bionano-scaling",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "AWS lambda function for scaling CCC autoscaling groups",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-compute-cannon",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Dion Amago Whitehead <dion.amago@autodesk.org>",
   "bin": {
     "ccc": "bin/cloudcomputecannon.js",

--- a/src/haxe/ccc/compute/client/js/ClientJSTools.hx
+++ b/src/haxe/ccc/compute/client/js/ClientJSTools.hx
@@ -82,6 +82,58 @@ class ClientJSTools
 #end
 	}
 
+// 	@:expose
+// 	public static function postTurboJob(host :String, job :BatchProcessRequestTurbo) :Promise<JobResultsTurbo>
+// 	{
+// 		var execute = function(resolve :JobResultsTurbo->Void, reject :Dynamic->Void) {
+
+// 			var jsonRpcRequest :RequestDef = {
+// 				id: JsonRpcConstants.JSONRPC_NULL_ID,
+// 				jsonrpc: JsonRpcConstants.JSONRPC_VERSION_2,
+// 				method: Constants.RPC_METHOD_JOB_SUBMIT,
+// 				params: job
+// 			}
+
+// 			var formData = {
+// 				jsonrpc: Json.stringify(jsonRpcRequest)
+// 			};
+// 			if (forms != null) {
+// 				for (f in Reflect.fields(forms)) {
+// 					Reflect.setField(formData, f, Reflect.field(forms, f));
+// 				}
+// 			}
+// 			//Simply by making this request a multi-part request is is assumed
+// 			//to be a job submission.
+// 			var url = rpcUrl(host);
+// 			Request.post({url:url, formData:formData},
+// 				function(err :js.Error, httpResponse :HttpResponse, body:Body) {
+// 					if (err != null) {
+// 						Log.error(err);
+// 						reject(err);
+// 						return;
+// 					}
+// 					if (httpResponse.statusCode == 200) {
+// 						try {
+// 							var result :ResponseDefSuccess<JobResult> = Json.parse(body);
+// 							resolve(result.result);
+// 						} catch (err :Dynamic) {
+// 							reject(err);
+// 						}
+// 					} else {
+// 						reject('non-200 response body=$body');
+// 					}
+// 				});
+// 		}
+
+// #if (promise == "js.npm.bluebird.Bluebird")
+// 		return new Promise(execute);
+// #else
+// 		var promise = new promhx.deferred.DeferredPromise();
+// 		execute(promise.resolve, promise.boundPromise.reject);
+// 		return promise.boundPromise;
+// #end
+// 	}
+
 	inline public static function rpcUrl(host :String) :UrlString
 	{
 		if (!host.startsWith('http')) {

--- a/src/haxe/ccc/compute/server/Server.hx
+++ b/src/haxe/ccc/compute/server/Server.hx
@@ -201,6 +201,11 @@ class Server
 			health: null
 		};
 		injector.map('ccc.compute.shared.WorkerStateInternal').toValue(workerInternalState);
+
+		var localhost :Host = 'localhost:$SERVER_DEFAULT_PORT';
+		injector.map(Host, 'serverhost').toValue(localhost);
+		var serverHostRPCAPI : UrlString = 'http://${localhost}${SERVER_RPC_URL}';
+		injector.map(UrlString, 'localRPCApi').toValue(serverHostRPCAPI);
 	}
 
 	static function initAppPaths(injector :Injector)
@@ -626,7 +631,7 @@ class Server
 		var disableStartTest = env[ENV_DISABLE_STARTUP_TEST] + '' == 'true' || env[ENV_DISABLE_STARTUP_TEST] == '1';
 		if (!disableStartTest) {
 			Log.debug('Running server functional tests');
-			promhx.RequestPromises.get('http://localhost:${SERVER_DEFAULT_PORT}${SERVER_RPC_URL}/server-tests?${isTravisBuild ? "core=true&storage=true&dockervolumes=true&compute=true&jobs=true" : "compute=true"}')
+			promhx.RequestPromises.get('http://localhost:${SERVER_DEFAULT_PORT}${SERVER_RPC_URL}/server-tests?${isTravisBuild ? "core=true&storage=true&dockervolumes=true&compute=true&jobs=true&turbojobs=true" : "turbojobs=true"}')
 				.then(function(out) {
 					try {
 						var results = Json.parse(out);

--- a/src/haxe/ccc/compute/server/Server.hx
+++ b/src/haxe/ccc/compute/server/Server.hx
@@ -631,7 +631,7 @@ class Server
 		var disableStartTest = env[ENV_DISABLE_STARTUP_TEST] + '' == 'true' || env[ENV_DISABLE_STARTUP_TEST] == '1';
 		if (!disableStartTest) {
 			Log.debug('Running server functional tests');
-			promhx.RequestPromises.get('http://localhost:${SERVER_DEFAULT_PORT}${SERVER_RPC_URL}/server-tests?${isTravisBuild ? "core=true&storage=true&dockervolumes=true&compute=true&jobs=true&turbojobs=true" : "turbojobs=true"}')
+			promhx.RequestPromises.get('http://localhost:${SERVER_DEFAULT_PORT}${SERVER_RPC_URL}/server-tests?${isTravisBuild ? "core=true&storage=true&dockervolumes=true&compute=true&jobs=true&turbojobs=true" : "compute=true&turbojobs=true"}')
 				.then(function(out) {
 					try {
 						var results = Json.parse(out);

--- a/src/haxe/ccc/compute/server/execution/BatchComputeDockerTurbo.hx
+++ b/src/haxe/ccc/compute/server/execution/BatchComputeDockerTurbo.hx
@@ -1,0 +1,308 @@
+package ccc.compute.server.execution;
+
+import haxe.remoting.JsonRpc;
+
+import js.npm.RedisClient;
+import js.npm.docker.Docker;
+import js.npm.tarstream.TarStream;
+
+import ccc.docker.dataxfer.DockerDataTools;
+
+import ccc.storage.*;
+
+import util.DateFormatTools;
+import util.DockerUrl;
+import util.DockerTools;
+
+typedef RunContainerResultTurbo = {
+	var container :DockerContainer;
+	var exitCode :Int;
+	var error :Dynamic;
+	var timedOut :Bool;
+	var stderr :Array<String>;
+	var stdout:Array<String>;
+	var copyInputsTime :String;
+	var containerExecutionTime :String;
+	var containerCreateTime :String;
+	var copyLogsTime :String;
+	var containerExecutionStart :Date;
+}
+
+/**
+ * Holds jobs waiting to be executed.
+ */
+class BatchComputeDockerTurbo
+{
+	public static function executeTurboJob(redis :RedisClient, job :BatchProcessRequestTurbo, docker :Docker, log :AbstractLogger) :Promise<JobResultsTurbo>
+	{
+		Assert.notNull(job);
+		var containerId = null;
+		var jobId = job.id;
+
+		var containerInputsPath = job.inputsPath == null ? '/${DIRECTORY_INPUTS}' : job.inputsPath;
+		var containerOutputsPath = job.outputsPath == null ? '/${DIRECTORY_OUTPUTS}' : job.outputsPath;
+
+		var ensureImage = BatchComputeDocker.ensureDockerImage.bind(docker, job.image, log, job.imagePullOptions);
+		var runContainer = runContainerTurbo.bind(job, docker, log);
+		var getOutputs = getOutputsTurbo2.bind(job, _, log);
+
+		var resultBlob :RunContainerResultTurbo = null;
+		var error :Dynamic;
+		var outputFiles :DynamicAccess<String> = null;
+
+		var stats :JobResultsTurboStats = {
+			copyInputs: null,
+			ensureImage: null,
+			containerCreation: null,
+			containerExecution: null,
+			copyOutputs: null,
+			copyLogs: null,
+			total: null
+		}
+		var startTime = Date.now();
+		return Promise.promise(true)
+			//Start doing the job stuff
+			//Pipe logs to file streams
+			//Copy the files to the remote worker
+			.pipe(function(_) {
+				return ensureImage()
+					.then(function(_) {
+						stats.ensureImage = DateFormatTools.getShortStringOfDateDiff(startTime, Date.now());
+						return true;
+					});
+			})
+			.pipe(function(_) {
+				var startTimeContainer = Date.now();
+				return runContainer()
+					.pipe(function(results) {
+						stats.containerExecution = DateFormatTools.getShortStringOfDateDiff(startTimeContainer, Date.now());
+						stats.containerCreation = results.containerCreateTime;
+						stats.copyLogs = results.copyLogsTime;
+						stats.copyInputs = results.copyInputsTime;
+						resultBlob = results;
+						error = resultBlob.error;
+						if (resultBlob != null && error == null && job.ignoreOutputs != true) {
+							var startTimeOutputs = Date.now();
+							return getOutputs(results.container)
+								.then(function(files) {
+									stats.copyOutputs = DateFormatTools.getShortStringOfDateDiff(startTimeOutputs, Date.now());
+									outputFiles = files;
+									return true;
+								});
+						} else {
+							stats.copyOutputs = '0';
+							return Promise.promise(true);
+						}
+					});
+			})
+			.then(function(_) {
+				var jobResultsFinal :JobResultsTurbo = {
+					outputs: outputFiles,
+					error: error,
+					stdout: resultBlob != null ? resultBlob.stdout : [],
+					stderr: resultBlob != null ? resultBlob.stderr : [],
+					exitCode: resultBlob != null ? resultBlob.exitCode : -1,
+					stats: stats
+				};
+				stats.total = DateFormatTools.getShortStringOfDateDiff(startTime, Date.now());
+				return jobResultsFinal;
+			});
+	}
+
+	static function createTarStreamFromFiles(files :DynamicAccess<String>) :TarPack
+	{
+		var tarStream = TarStream.pack();
+		for (fileName in files.keys()) {
+			tarStream.entry({name: fileName}, files.get(fileName));
+		}
+		tarStream.finalize();
+		return tarStream;
+	}
+
+	static function runContainerTurbo(job :BatchProcessRequestTurbo, docker :Docker, log :AbstractLogger) :Promise<RunContainerResultTurbo>
+	{
+		var jobId = job.id;
+
+		var result :RunContainerResultTurbo = {
+			container: null,
+			exitCode: -1,
+			error: null,
+			timedOut: false,
+			stdout: [],
+			stderr: [],
+			copyInputsTime: null,
+			containerExecutionTime: null,
+			containerCreateTime: null,
+			copyLogsTime: null,
+			containerExecutionStart: null,
+		};
+
+		var startTime = Date.now();
+
+		/*
+			First check if there is an existing container
+			running, in case we crashed and resumed
+		 */
+		return Promise.promise(true)
+			.pipe(function(_) {
+				var containerInputsPath = job.inputsPath == null ? '/${DIRECTORY_INPUTS}' : job.inputsPath;
+				var containerOutputsPath = job.outputsPath == null ? '/${DIRECTORY_OUTPUTS}' : job.outputsPath;
+
+				var imageId = job.image;
+
+				var opts :CreateContainerOptions = {
+					Image: null,//Set below
+					AttachStdout: false,
+					AttachStderr: false,
+					Tty: false,
+				};
+
+				opts.Cmd = opts.Cmd != null ? opts.Cmd : job.command;
+				opts.WorkingDir = opts.WorkingDir != null ? opts.WorkingDir : job.workingDir;
+				opts.HostConfig = opts.HostConfig != null ? opts.HostConfig : {};
+				opts.HostConfig.LogConfig = {Type:DockerLoggingDriver.jsonfile, Config:{}};
+
+				opts.Image = opts.Image != null ? opts.Image : imageId.toLowerCase();
+				opts.Env = js.npm.redis.RedisLuaTools.isArrayObjectEmpty(opts.Env) ? [] : opts.Env;
+				for (env in [
+					'INPUTS=$containerInputsPath',
+					'OUTPUTS=$containerOutputsPath',
+					]) {
+					opts.Env.push(env);
+				}
+
+				opts.Labels = opts.Labels != null ? opts.Labels : {};
+				Reflect.setField(opts.Labels, 'jobId', jobId);
+
+				log.debug({opts:opts});
+
+				var copyInputsOpts = {
+					path: '/',
+					noOverwriteDirNonDir: 'true'
+				}
+
+				var modifiedPathInputs :DynamicAccess<String> = null;
+				if (job.inputs != null && job.inputs.keys().length > 0) {
+					modifiedPathInputs = {};
+					for (key in job.inputs.keys()) {
+						modifiedPathInputs['$containerInputsPath/$key'] = job.inputs[key];
+					}
+				}
+
+				var inputStream = modifiedPathInputs != null ? createTarStreamFromFiles(modifiedPathInputs) : null;
+
+				return DockerJobTools.runDockerContainer(docker, opts, inputStream, inputStream != null ? copyInputsOpts : null, null, log)
+					.then(function(containerunResult) {
+						result.error = containerunResult.error;
+						result.copyInputsTime = containerunResult.copyInputsTime;
+						result.container = containerunResult.container;
+						result.containerExecutionStart = containerunResult.containerExecutionStart;
+						result.containerCreateTime = containerunResult.containerCreateTime;
+						log = log.child({container:result.container.id});
+						return containerunResult != null ? containerunResult.container : null;
+					});
+			})
+			.pipe(function(container) {
+				if (container == null) {
+					throw 'Missing container when attempting to run';
+					return Promise.promise(true);
+				} else {
+					//Wait for the container to finish, but also monitor
+					//the state of the job. If it becomes 'stopped'
+					var getLogsStartTime = Date.now();
+					var logsPromise = DockerTools.getContainerLogs2(container)
+						.then(function(stdOutErr) {
+							result.copyLogsTime = DateFormatTools.getShortStringOfDateDiff(getLogsStartTime, Date.now());
+							result.stdout = stdOutErr.stdout != null ? stdOutErr.stdout : result.stdout;
+							result.stderr = stdOutErr.stderr != null ? stdOutErr.stderr : result.stderr;
+							return true;
+						});
+
+
+					var promise = new DeferredPromise();
+
+					var timeout :Int = job.parameters.maxDuration;
+					if (timeout == null) {
+						timeout = DEFAULT_MAX_JOB_TIME_MS;
+					}
+					var timeoutId = Node.setTimeout(function() {
+						log.warn({message:'Timed out'});
+						result.timedOut = true;
+						if (promise != null) {
+							promise.resolve(true);
+							promise = null;
+							log.warn('Calling kill container ${container.id} because of a timeout');
+							container.kill(function(err,_) {});
+						}
+					}, timeout * 1000);
+
+					promise.boundPromise
+						.errorPipe(function(err) {
+							return Promise.promise(true);
+						})
+						.then(function(_) {
+							Node.clearTimeout(timeoutId);
+						});
+
+					DockerPromises.wait(container)
+						.then(function(status :{StatusCode:Int}) {
+							if (promise == null) {
+								return;
+							}
+							result.exitCode = status.StatusCode;
+							//This is caused by a job failure
+							if (result.exitCode == 137) {
+								result.error = "Job exitCode==137 this is caused by docker killing the container, likely on a restart.";
+							}
+
+							result.containerExecutionTime = DateFormatTools.getShortStringOfDateDiff(result.containerExecutionStart, Date.now());
+							// result.copyInputsTime = DateFormatTools.getShortStringOfDateDiff(startInputCopyTime, Date.now());
+
+							log.debug({exitcode:result.exitCode, error:error});
+							if (error != null) {
+								log.warn({exitcode:result.exitCode, error:error});
+							}
+							promise.resolve(true);
+							promise = null;
+						})
+						.catchError(function(err) {
+							if (promise != null) {
+								promise.boundPromise.reject(err);
+							} else {
+								log.error({error:err, message:'Caught error but container execution already resolved'});
+							}
+							promise = null;
+						});
+
+					return Promise.whenAll([promise.boundPromise, logsPromise])
+						.thenTrue();
+				}
+			})
+			.then(function(_) {
+				return result;
+			});
+	}
+
+	static function getOutputsTurbo(job :BatchProcessRequestTurbo, docker :Docker, log :AbstractLogger) :Promise<{files:DynamicAccess<String>, disposed:Promise<Bool>}>
+	{
+		var jobId = job.id;
+		var outputVolumeName = JobTools.getWorkerVolumeNameOutputs(jobId);
+
+		var outputsVolume :MountedDockerVolumeDef = {
+			docker: docker,
+			name: outputVolumeName,
+		};
+
+		return DockerDataTools.getDataFiles(outputsVolume);
+	}
+
+	static function getOutputsTurbo2(job :BatchProcessRequestTurbo, container :DockerContainer, log :AbstractLogger) :Promise<DynamicAccess<String>>
+	{
+		var path = job.outputsPath != null ? job.outputsPath : '/${DIRECTORY_OUTPUTS}';
+		return DockerDataTools.getDataFilesFromContainer(container, path)
+			.errorPipe(function(err) {
+				log.warn({error:err, f:'getOutputsTurbo2'});
+				return Promise.promise(null);
+			});
+	}
+}

--- a/src/haxe/ccc/compute/server/execution/routes/RpcRoutes.hx
+++ b/src/haxe/ccc/compute/server/execution/routes/RpcRoutes.hx
@@ -242,6 +242,72 @@ class RpcRoutes
 	}
 
 	@rpc({
+		alias:'runturbo',
+		doc:'Run docker job(s) on the compute provider. Example:\n cloudcannon run --image=elyase/staticpython --command=\'["python", "-c", "print(\'Hello World!\')"]\'',
+		args:{
+			'command': {'doc':'Command to run in the docker container. E.g. --command=\'["echo", "foo"]\''},
+			'image': {'doc': 'Docker image name [busybox].'},
+			'imagePullOptions': {'doc': 'Docker image pull options, e.g. auth credentials'},
+			'inputs': {'doc': 'Object hash of inputs.'},
+			'workingDir': {'doc': 'The current working directory for the process in the docker container.'},
+			'cpus': {'doc': 'Minimum number of CPUs required for this process.'},
+			'maxDuration': {'doc': 'Maximum time (in seconds) this job will be allowed to run before being terminated.'},
+			'meta': {'doc': 'Metadata logged and saved with the job description and results.json'}
+		}
+	})
+	public function submitTurboJob(
+		?image :String,
+#if ((nodejs && !macro) && !excludeccc)
+		?imagePullOptions :PullImageOptions,
+#else
+		?imagePullOptions :Dynamic,
+#end
+		?command :Array<String>,
+		?inputs :Dynamic<String>,
+		?workingDir :String,
+		?cpus :Int = 1,
+		?maxDuration :Int = 600,
+		?inputsPath :String,
+		?outputsPath :String,
+		?meta :Dynamic
+		) :Promise<JobResultsTurbo>
+	{
+		var request :BatchProcessRequestTurbo = {
+			image: image,
+			imagePullOptions: imagePullOptions,
+			command: command,
+			inputs: inputs,
+			workingDir: workingDir,
+			parameters: {cpus: cpus, maxDuration:maxDuration},
+			inputsPath: inputsPath,
+			outputsPath: outputsPath,
+			meta: meta
+		}
+
+#if ((nodejs && !macro) && !excludeccc)
+		return ServiceBatchComputeTools.runTurboJobRequest(_injector, request);
+#else
+		return Promise.promise(null);
+#end
+	}
+
+	@rpc({
+		alias:'runturbojson',
+		doc:'Run docker job(s) on the compute provider. Example:\n cloudcannon run --image=elyase/staticpython --command=\'["python", "-c", "print(\'Hello World!\')"]\'',
+		args:{
+			'job': {'doc':'BatchProcessRequestTurbo'}
+		}
+	})
+	public function submitTurboJobJson(job :BatchProcessRequestTurbo) :Promise<JobResultsTurbo>
+	{
+#if ((nodejs && !macro) && !excludeccc)
+		return ServiceBatchComputeTools.runTurboJobRequest(_injector, job);
+#else
+		return Promise.promise(null);
+#end
+	}
+
+	@rpc({
 		alias:'submitjob',
 		doc:'Run docker job(s) on the compute provider. Example:\n cloudcannon run --image=elyase/staticpython --command=\'["python", "-c", "print(\'Hello World!\')"]\'',
 		args:{

--- a/src/haxe/ccc/compute/server/job/Jobs.hx
+++ b/src/haxe/ccc/compute/server/job/Jobs.hx
@@ -105,7 +105,6 @@ abstract Jobs(RedisClient) from RedisClient
 	{
 		return JobScripts.evaluateLuaScript(this, JobScripts.SCRIPT_WORKERS_FAILED, [Json.stringify(workerIds)])
 			.then(function(dataString) {
-				traceMagenta('dataString=$dataString');
 				return true;
 			});
 	}

--- a/src/haxe/ccc/compute/server/job/TurboJobs.hx
+++ b/src/haxe/ccc/compute/server/job/TurboJobs.hx
@@ -1,0 +1,23 @@
+package ccc.compute.server.job;
+
+import js.npm.RedisClient;
+import js.npm.redis.RedisLuaTools;
+
+abstract TurboJobs(RedisClient) from RedisClient
+{
+	inline function new(r :RedisClient)
+	{
+		this = r;
+	}
+
+	inline public function init()
+	{
+		return Promise.promise(true);
+	}
+
+	inline public function startJob(jobId :JobId, ttl :Int) :Promise<Bool>
+	{
+		return RedisPromises.setex(this, '${CCC_PREFIX}turbojob${SEP}$jobId${SEP}$ttl', ttl, jobId)
+			.thenTrue();
+	}
+}

--- a/src/haxe/ccc/compute/server/scaling/ShutdownController.hx
+++ b/src/haxe/ccc/compute/server/scaling/ShutdownController.hx
@@ -31,7 +31,6 @@ class ShutdownController
 	@post
 	public function postInject()
 	{
-		traceMagenta('SHutdownController postInject');
 		log = log.child({c:Type.getClassName(Type.getClass(this)).split('.').pop()});
 
 		if (Sys.environment().get(ENV_SCALE_DOWN_CONTROL) == 'internal') {

--- a/src/haxe/ccc/compute/server/tests/ServerAPITestBase.hx
+++ b/src/haxe/ccc/compute/server/tests/ServerAPITestBase.hx
@@ -2,20 +2,8 @@ package ccc.compute.server.tests;
 
 class ServerAPITestBase extends haxe.unit.async.PromiseTest
 {
-	var _serverHost :Host;
-	var _serverHostRPCAPI :UrlString;
+	@inject('serverhost') public var _serverHost :Host;
+	@inject('localRPCApi') public var _serverHostRPCAPI :UrlString;
 
-	public function new(targetHost :Host)
-	{
-		_serverHost = targetHost;
-		_serverHostRPCAPI = 'http://${_serverHost}${SERVER_RPC_URL}';
-	}
-
-	// override public function setup() :Null<Promise<Bool>>
-	// {
-	// 	return super.setup()
-	// 		.pipe(function(_) {
-	// 			return ServerTestTools.resetRemoteServer(_serverHost);
-	// 		});
-	// }
+	public function new() {}
 }

--- a/src/haxe/ccc/compute/server/tests/ServerTestTools.hx
+++ b/src/haxe/ccc/compute/server/tests/ServerTestTools.hx
@@ -20,8 +20,9 @@ class ServerTestTools
 		}
 	}
 
-	public static function getProxy(rpcUrl :UrlString)
+	public static function getProxy(?rpcUrl :UrlString)
 	{
+		rpcUrl = rpcUrl != null ? rpcUrl : SERVER_LOCAL_RPC_URL;
 		var proxy = t9.remoting.jsonrpc.Macros.buildRpcClient(ccc.compute.server.execution.routes.RpcRoutes, true)
 			.setConnection(new t9.remoting.jsonrpc.JsonRpcConnectionHttpPost(rpcUrl));
 		return proxy;

--- a/src/haxe/ccc/compute/server/tests/TestCompute.hx
+++ b/src/haxe/ccc/compute/server/tests/TestCompute.hx
@@ -180,8 +180,8 @@ cat /$DIRECTORY_INPUTS/$inputName3 > /$DIRECTORY_OUTPUTS/$outputName3
 			});
 	}
 
-	public function new(targetHost :Host)
+	public function new()
 	{
-		super(targetHost);
+		super();
 	}
 }

--- a/src/haxe/ccc/compute/server/tests/TestFailureConditions.hx
+++ b/src/haxe/ccc/compute/server/tests/TestFailureConditions.hx
@@ -93,8 +93,5 @@ class TestFailureConditions extends ServerAPITestBase
 			});
 	}
 
-	public function new(targetHost :Host)
-	{
-		super(targetHost);
-	}
+	public function new() { super(); }
 }

--- a/src/haxe/ccc/compute/server/tests/TestJobs.hx
+++ b/src/haxe/ccc/compute/server/tests/TestJobs.hx
@@ -787,8 +787,5 @@ exit 0
 		return promise.boundPromise;
 	}
 
-	public function new(targetHost :Host)
-	{
-		super(targetHost != null ? targetHost : new Host(new HostName('localhost'), new Port(SERVER_DEFAULT_PORT)));
-	}
+	public function new() { super(); }
 }

--- a/src/haxe/ccc/compute/server/tests/TestStorageBase.hx
+++ b/src/haxe/ccc/compute/server/tests/TestStorageBase.hx
@@ -25,12 +25,14 @@ using promhx.PromiseTools;
 
 class TestStorageBase extends haxe.unit.async.PromiseTest
 {
-	public var _storage :ServiceStorage;
+	@inject public var _storage :ServiceStorage;
 
-	public function new(?storage :ServiceStorage)
+	public function new() {}
+
+	@post
+	public function postInject()
 	{
-		if (storage != null) {
-			_storage = storage;
+		if (_storage != null) {
 			var date = DateTools.format(Date.now(), '%Y%m%d-%H%M%S');
 			_storage = _storage.appendToRootPath('tests/storage/$date');
 		}

--- a/src/haxe/ccc/compute/server/tests/TestStorageLocal.hx
+++ b/src/haxe/ccc/compute/server/tests/TestStorageLocal.hx
@@ -2,11 +2,6 @@ package ccc.compute.server.tests;
 
 class TestStorageLocal extends TestStorageBase
 {
-	public function new(?storage :ccc.storage.ServiceStorageLocalFileSystem)
-	{
-		super(storage);
-	}
-
 	@timeout(1000)
 	public function testPathsLocal() :Promise<Bool>
 	{
@@ -18,4 +13,6 @@ class TestStorageLocal extends TestStorageBase
 	{
 		return doStorageTest(_storage);
 	}
+
+	public function new() { super(); }
 }

--- a/src/haxe/ccc/compute/server/tests/TestStoragePkgCloud.hx
+++ b/src/haxe/ccc/compute/server/tests/TestStoragePkgCloud.hx
@@ -7,11 +7,6 @@ import util.streams.StreamTools;
 
 class TestStoragePkgCloud extends TestStorageBase
 {
-	public function new(?storage :ccc.storage.ServiceStoragePkgCloud)
-	{
-		super(storage);
-	}
-
 	@timeout(1000)
 	public function testPathsS3() :Promise<Bool>
 	{
@@ -328,4 +323,6 @@ class TestStoragePkgCloud extends TestStorageBase
 	// 			return true;
 	// 		});
 	// }
+
+	public function new() { super(); }
 }

--- a/src/haxe/ccc/compute/server/tests/TestStorageS3.hx
+++ b/src/haxe/ccc/compute/server/tests/TestStorageS3.hx
@@ -11,11 +11,6 @@ import util.streams.StreamTools;
 
 class TestStorageS3 extends TestStorageBase
 {
-	public function new(?storage :ServiceStorageS3)
-	{
-		super(storage);
-	}
-
 	override public function setup() :Promise<Bool>
 	{
 		return super.setup()
@@ -335,4 +330,6 @@ class TestStorageS3 extends TestStorageBase
 	// 			return true;
 	// 		});
 	// }
+
+	public function new() { super(); }
 }

--- a/src/haxe/ccc/compute/server/tests/TestTurboJobs.hx
+++ b/src/haxe/ccc/compute/server/tests/TestTurboJobs.hx
@@ -1,0 +1,100 @@
+package ccc.compute.server.tests;
+
+import ccc.compute.client.js.ClientJSTools;
+
+import haxe.DynamicAccess;
+import haxe.io.*;
+
+import haxe.remoting.JsonRpc;
+
+import js.npm.shortid.ShortId;
+
+import promhx.StreamPromises;
+import promhx.RequestPromises;
+import promhx.deferred.DeferredPromise;
+
+class TestTurboJobs extends ServerAPITestBase
+{
+	public static var TEST_BASE = 'tests';
+	@inject public var _fs :ServiceStorage;
+	@inject public var routes :ccc.compute.server.execution.routes.RpcRoutes;
+
+	@timeout(240000)
+	public function testTurboJobComplete() :Promise<Bool>
+	{
+		var TESTNAME = 'testTurboJobComplete';
+
+		var random = ShortId.generate();
+
+		var customInputsPath = '$TEST_BASE/$TESTNAME/$random/$DIRECTORY_INPUTS';
+		var customOutputsPath = '$TEST_BASE/$TESTNAME/$random/$DIRECTORY_OUTPUTS';
+		var customResultsPath = '$TEST_BASE/$TESTNAME/$random/results';
+
+		var inputs :DynamicAccess<String> = {};
+
+		var inputName2 = 'in${ShortId.generate()}';
+		var inputName3 = 'in${ShortId.generate()}';
+		inputs[inputName2] = 'in${ShortId.generate()}';
+		inputs[inputName3] = 'in${ShortId.generate()}';
+
+		var outputName1 = 'out${ShortId.generate()}';
+		var outputName2 = 'out${ShortId.generate()}';
+		var outputName3 = 'out${ShortId.generate()}';
+
+		var outputValue1 = 'out${ShortId.generate()}';
+
+		var outputValueStdout = 'out${ShortId.generate()}';
+		var outputValueStderr = 'out${ShortId.generate()}';
+		//Multiline stdout
+		var script =
+'#!/bin/sh
+echo "$outputValueStdout"
+echo "$outputValueStdout"
+echo foo
+echo "$outputValueStdout"
+echo "$outputValueStderr" >> /dev/stderr
+mkdir -p /$DIRECTORY_OUTPUTS
+echo "$outputValue1" > /$DIRECTORY_OUTPUTS/$outputName1
+cat /$DIRECTORY_INPUTS/$inputName2 > /$DIRECTORY_OUTPUTS/$outputName2
+cat /$DIRECTORY_INPUTS/$inputName3 > /$DIRECTORY_OUTPUTS/$outputName3
+';
+		var targetStdout = '$outputValueStdout\n$outputValueStdout\nfoo\n$outputValueStdout'.trim();
+		var targetStderr = '$outputValueStderr';
+		var scriptName = 'script.sh';
+		inputs[scriptName] = script;
+
+		var random = ShortId.generate();
+
+		var request: BatchProcessRequestTurbo = {
+			inputs: inputs,
+			image: DOCKER_IMAGE_DEFAULT,
+			command: ["/bin/sh", '/$DIRECTORY_INPUTS/$scriptName'],
+			parameters: {maxDuration:30, cpus:1}
+		}
+
+		var jobId :JobId = null;
+
+		var proxy = ServerTestTools.getProxy();
+		return proxy.submitTurboJobJson(request)
+			.then(function(jobResult :JobResultsTurbo) {
+				traceMagenta('jobResult=$jobResult');
+				if (jobResult == null) {
+					throw 'jobResult should not be null. Check the above section';
+				}
+				assertNotNull(jobResult.outputs);
+				assertNotNull(jobResult.outputs[outputName1]);
+				assertNotNull(jobResult.outputs[outputName2]);
+				assertNotNull(jobResult.outputs[outputName3]);
+				assertEquals(jobResult.outputs[outputName1].trim(), outputValue1);
+				assertEquals(jobResult.outputs[outputName2].trim(), inputs[inputName2]);
+				assertEquals(jobResult.outputs[outputName3].trim(), inputs[inputName3]);
+
+				assertEquals(jobResult.stderr[0].trim(), outputValueStderr);
+				assertEquals(jobResult.stdout[0].trim(), outputValueStdout);
+
+				return true;
+			});
+	}
+
+	public function new() { super(); }
+}

--- a/src/haxe/ccc/compute/shared/Constants.hx
+++ b/src/haxe/ccc/compute/shared/Constants.hx
@@ -50,6 +50,7 @@ class Constants
 	public static inline var STDOUT_FILE = 'stdout';
 	public static inline var STDERR_FILE = 'stderr';
 	public static inline var DEFAULT_MAX_JOB_TIME_MS = 30 * 1000;//30secs
+	public static inline var TURBO_JOB_MAX_TIME_SECONDS_DEFAULT :Int = 30;
 
 	/* Env vars */
 	inline public static var ENV_VAR_DISABLE_LOGGING = 'DISABLE_LOGGING';

--- a/src/haxe/ccc/compute/shared/Definitions.hx
+++ b/src/haxe/ccc/compute/shared/Definitions.hx
@@ -166,6 +166,46 @@ typedef BasicBatchProcessRequest = {
 	@:optional var appendStdErr :Bool;
 	@:optional var mountApiServer :Bool;
 	@:optional var priority :Bool;
+	/* No job persistance, no durability, no redis, just speed */
+	@:optional var turbo :Bool;
+}
+
+typedef BatchProcessRequestTurbo = {
+	@:optional var id :JobId;
+	@:optional var inputs :DynamicAccess<String>;
+	@:optional var image :String;
+#if clientjs
+	@:optional var imagePullOptions :Dynamic;
+#else
+	@:optional var imagePullOptions :PullImageOptions;
+#end
+	@:optional var command :Array<String>;
+	@:optional var workingDir :String;
+	@:optional var parameters :JobParams;
+	@:optional var inputsPath :String;
+	@:optional var outputsPath :String;
+	@:optional var meta :Dynamic<String>;
+	/* We can save time if outputs are ignored */
+	@:optional var ignoreOutputs :Bool;
+}
+
+typedef JobResultsTurboStats = {
+	var ensureImage :String;
+	var copyInputs :String;
+	var containerCreation :String;
+	var containerExecution :String;
+	var copyLogs :String;
+	var copyOutputs :String;
+	var total :String;
+}
+
+typedef JobResultsTurbo = {
+	var stdout :Array<String>;
+	var stderr :Array<String>;
+	var exitCode :Int;
+	var outputs :DynamicAccess<String>;
+	@:optional var error :Dynamic;
+	@:optional var stats :JobResultsTurboStats;
 }
 
 /**

--- a/src/haxe/promhx/DockerPromises.hx
+++ b/src/haxe/promhx/DockerPromises.hx
@@ -243,4 +243,11 @@ class DockerPromises
 		volume.remove(promise.cb1);
 		return promise;
 	}
+
+	public static function copyIn(container :DockerContainer, input :IReadable, opts :{path:String, ?noOverwriteDirNonDir:String}) :Promise<Dynamic>
+	{
+		var promise = new promhx.CallbackPromise();
+		container.putArchive(input, opts, promise.cb2);
+		return promise;
+	}
 }

--- a/src/haxe/promhx/PromiseTools.hx
+++ b/src/haxe/promhx/PromiseTools.hx
@@ -145,7 +145,7 @@ class PromiseTools
 	public static function traceThen<T>(promise :Promise<T>, s :String) :Promise<T>
 	{
 		return promise.then(function(val) {
-			trace(s);
+			t9.util.ColorTraces.traceCyan(s);
 			return val;
 		});
 	}

--- a/src/haxe/promhx/StreamPromises.hx
+++ b/src/haxe/promhx/StreamPromises.hx
@@ -114,4 +114,28 @@ class StreamPromises
 		});
 		return promise.boundPromise;
 	}
+
+	public static function streamToStringArray(stream :IReadable) :Promise<Array<String>>
+	{
+		var promise = new DeferredPromise();
+		var strings :Array<String> = [];
+		stream.on(ReadableEvent.Error, function(err) {
+			if (promise != null) {
+				promise.boundPromise.reject(err);
+				promise = null;
+			} else {
+				Log.error(err);
+			}
+		});
+		stream.once(ReadableEvent.End, function() {
+			if (promise != null) {
+				promise.resolve(strings);
+				promise = null;
+			}
+		});
+		stream.on(ReadableEvent.Data, function(chunk :Buffer) {
+			strings.push(chunk.toString());
+		});
+		return promise.boundPromise;
+	}
 }

--- a/src/haxe/util/TarTools.hx
+++ b/src/haxe/util/TarTools.hx
@@ -1,6 +1,7 @@
 package util;
 
 import haxe.Resource;
+import haxe.DynamicAccess;
 
 import js.node.stream.Readable;
 import js.npm.tarstream.TarStream;
@@ -12,7 +13,7 @@ using StringTools;
 
 class TarTools
 {
-	public static function createTarStreamFromStrings(entries :Map<String,String>) :IReadable
+	public static function createTarStreamFromStrings(entries :DynamicAccess<String>) :IReadable
 	{
 		var tarStream = TarStream.pack();
 		for (name in entries.keys()) {

--- a/test/src/storage/TestStorageLocal.hx
+++ b/test/src/storage/TestStorageLocal.hx
@@ -36,6 +36,13 @@ class TestStorageLocal extends TestStorageBase
 
 	public function new() {super();}
 
+	@post
+	public function postInject()
+	{
+		_storage = ccc.storage.ServiceStorageLocalFileSystem.getService();
+		super.postInject();
+	}
+
 	override public function setup() :Null<Promise<Bool>>
 	{
 		_testPath = '/tmp/storageTest' + Math.floor(Math.random() * 1000000);


### PR DESCRIPTION
Fixes #126

 - Turbo jobs sacrifice durability and handling failed workers for speed.
 - No copying data to S3.
 - No storing jobs in a queue (job is executing on the machine getting the request).

For a basic job (copying tiny inputs) the breakdown of time is:
```
stats : {
	copyInputs : 0.193s,
	ensureImage : 0.08s,
	containerCreation : 0.189s,
	containerExecution : 1.351s,
	copyOutputs : 0.196s,
	copyLogs : 0.009s,
	total : 1.628s
}
```

Apparently there is a minimum cost of docker container creation and startup, even if the actual bash process takes almost no time.