### PR TITLE
Rearrange environment settings blocks, lambda tag usage and redis name

### DIFF
--- a/etc/bionano/aws/cloudformation/lambda-autoscaling/cf-ccc-scaling.json
+++ b/etc/bionano/aws/cloudformation/lambda-autoscaling/cf-ccc-scaling.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
-  "Description": "(v1.0.1) CCC scaling. Custom to bionano infrastructure",
+  "Description": "(v1.0.2) CCC scaling. Custom to bionano infrastructure",
 
   "Parameters": {
     "S3Bucket": {
@@ -21,27 +21,17 @@
       "Type": "String",
       "Default": "dev",
       "AllowedValues" : ["dev", "qa", "prod"]
-    }
+    },
+    "SubNetIds": {
+      "Description": "Subnetworks for servers to be scalled into. Seperate multiple entries by commas ','.",
+      "Type": "List<AWS::EC2::Subnet::Id>"
+    },
+    "SecGroupIds": {
+      "Description": "Subnetworks for servers to be scalled into. Seperate multiple entries by commas ','.",
+      "Type": "List<AWS::EC2::SecurityGroup::Id>"
+    }    
   },
 
- "Mappings" : {
-    "Settings": {
-      "dev" : {
-                "SubnetIds"        : ["subnet-a415dbd2", "subnet-522f9a36"], 
-                "SecurityGroupIds" : ["sg-ab9292cc"]
-              },
-
-      "qa" : {
-                "SubnetIds"        : ["subnet-698bab1f", "subnet-fca680c1"],
-                "SecurityGroupIds" : ["sg-fd5efb86"]
-              },
-
-      "prod" : {
-                "SubnetIds"        : ["subnet-feae88c3", "subnet-6b98b81d"], 
-                "SecurityGroupIds" : ["sg-87389dfc"]
-              }
-    }
-  },
 
   "Resources": {
 
@@ -64,8 +54,8 @@
         "Runtime" : "nodejs4.3",
         "Timeout" : 30,
         "VpcConfig" : {
-          "SecurityGroupIds" : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SecurityGroupIds" ] },
-          "SubnetIds" : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SubnetIds" ] }
+          "SecurityGroupIds" : {"Ref" : "SecGroupIds"},
+          "SubnetIds" : {"Ref" : "SubNetIds"}
         }
       }
     },
@@ -89,8 +79,8 @@
         "Runtime" : "nodejs4.3",
         "Timeout" : 30,
         "VpcConfig" : {
-          "SecurityGroupIds" : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SecurityGroupIds" ] },
-          "SubnetIds" : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SubnetIds" ] }
+          "SecurityGroupIds" : {"Ref" : "SecGroupIds"},
+          "SubnetIds" : {"Ref" : "SubNetIds"}
         }
       }
     },

--- a/etc/bionano/aws/cloudformation/lambda-autoscaling/cf-ccc-scaling.json
+++ b/etc/bionano/aws/cloudformation/lambda-autoscaling/cf-ccc-scaling.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
-  "Description": "CCC scaling. Custom to bionano infrastructure",
+  "Description": "(v1.0.1) CCC scaling. Custom to bionano infrastructure",
 
   "Parameters": {
     "S3Bucket": {
@@ -26,16 +26,20 @@
 
  "Mappings" : {
     "Settings": {
-      "SubnetIds" : {
-        "dev"  : ["subnet-a415dbd2", "subnet-522f9a36"],
-        "qa"   : ["subnet-698bab1f", "subnet-fca680c1"],
-        "prod" : ["subnet-feae88c3", "subnet-6b98b81d"]
-      },
-      "SecurityGroupIds" : {
-        "dev"  : ["sg-ab9292cc"],
-        "qa"   : ["sg-fd5efb86"],
-        "prod" : ["sg-87389dfc"]
-      }
+      "dev" : {
+                "SubnetIds"        : ["subnet-a415dbd2", "subnet-522f9a36"], 
+                "SecurityGroupIds" : ["sg-ab9292cc"]
+              },
+
+      "qa" : {
+                "SubnetIds"        : ["subnet-698bab1f", "subnet-fca680c1"],
+                "SecurityGroupIds" : ["sg-fd5efb86"]
+              },
+
+      "prod" : {
+                "SubnetIds"        : ["subnet-feae88c3", "subnet-6b98b81d"], 
+                "SecurityGroupIds" : ["sg-87389dfc"]
+              }
     }
   },
 
@@ -60,8 +64,8 @@
         "Runtime" : "nodejs4.3",
         "Timeout" : 30,
         "VpcConfig" : {
-          "SecurityGroupIds" : {"Fn::FindInMap" : [ "Settings", "SecurityGroupIds", { "Ref" : "BionanoEnvironment" } ] },
-          "SubnetIds" : {"Fn::FindInMap" : [ "Settings", "SubnetIds", { "Ref" : "BionanoEnvironment" } ] }
+          "SecurityGroupIds" : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SecurityGroupIds" ] },
+          "SubnetIds" : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SubnetIds" ] }
         }
       }
     },
@@ -85,8 +89,8 @@
         "Runtime" : "nodejs4.3",
         "Timeout" : 30,
         "VpcConfig" : {
-          "SecurityGroupIds" : {"Fn::FindInMap" : [ "Settings", "SecurityGroupIds", { "Ref" : "BionanoEnvironment" } ] },
-          "SubnetIds" : {"Fn::FindInMap" : [ "Settings", "SubnetIds", { "Ref" : "BionanoEnvironment" } ] }
+          "SecurityGroupIds" : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SecurityGroupIds" ] },
+          "SubnetIds" : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SubnetIds" ] }
         }
       }
     },

--- a/etc/bionano/aws/cloudformation/lambda-autoscaling/src/index.js
+++ b/etc/bionano/aws/cloudformation/lambda-autoscaling/src/index.js
@@ -3,8 +3,8 @@ var AWS = require('aws-sdk');
 var Promise = require('bluebird');
 
 var BNR_ENVIRONMENT = process.env['BNR_ENVIRONMENT'];
-var redisUrl = 'redis.' + BNR_ENVIRONMENT + '.bionano.bio';
-var StackTagValue = BNR_ENVIRONMENT + '-ccc';
+var redisUrl = 'redis-ccc.' + BNR_ENVIRONMENT + '.bionano.bio';
+var AppTagValue = 'ccc';
 
 var autoscaling = new AWS.AutoScaling();
 var ec2 = new AWS.EC2();
@@ -49,7 +49,8 @@ function getAutoscalingGroup(disableCache) {
 					if (tags) {
 						for (var j = 0; j < tags.length; j++) {
 							var tag = tags[j];
-							if (tag['Key'] == 'stack' && tag['Value'].startsWith(StackTagValue)) {
+							// allowing both app=(ccc | ccc-v1) and environment=(dev | dev-v2). iterating app tag first as there should be fewer hits for that
+							if (tag['Key'] == 'app' && tag['Value'].startsWith(AppTagValue) && tag['Key'] == 'environment' && tag['Value'].startsWith(BNR_ENVIRONMENT) ) {
 								cccAutoscalingGroup = asg;
 								AutoscalingGroupName = asg.AutoscalingGroupName;
 								break;

--- a/etc/bionano/aws/cloudformation/redis/cf-ccc-redis.json
+++ b/etc/bionano/aws/cloudformation/redis/cf-ccc-redis.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
-  "Description": "(v1.0.1) CCC redis cluster. Custom to bionano infrastructure",
+  "Description": "(v1.0.2) CCC redis cluster. Custom to bionano infrastructure",
 
   "Parameters": {
     "BionanoEnvironment": {
@@ -15,26 +15,20 @@
       "Type" : "String",
       "AllowedValues" : [ "cache.t1.micro", "cache.m1.small", "cache.m1.medium", "cache.m1.large", "cache.m1.xlarge", "cache.m2.xlarge", "cache.m2.2xlarge", "cache.m2.4xlarge", "cache.m3.xlarge", "cache.m3.2xlarge", "cache.c1.xlarge" ],
       "ConstraintDescription" : "must select a valid Cache Node type."
+    },
+    "SubNetIds": {
+      "Description": "Subnetworks for servers to be scalled into. Seperate multiple entries by commas ','.",
+      "Type": "List<AWS::EC2::Subnet::Id>"
+    },
+    "SecGroupIds": {
+      "Description": "Subnetworks for servers to be scalled into. Seperate multiple entries by commas ','.",
+      "Type": "List<AWS::EC2::SecurityGroup::Id>"
     }
+
   },
 
  "Mappings" : {
     "Settings": {
-      "dev" : {
-                "SubnetIds"        : ["subnet-a415dbd2", "subnet-522f9a36"], 
-                "SecurityGroupIds" : ["sg-ab9292cc"]
-              },
-
-      "qa" : {
-                "SubnetIds"        : ["subnet-698bab1f", "subnet-fca680c1"],
-                "SecurityGroupIds" : ["sg-fd5efb86"]
-              },
-
-      "prod" : {
-                "SubnetIds"        : ["subnet-feae88c3", "subnet-6b98b81d"], 
-                "SecurityGroupIds" : ["sg-87389dfc"]
-              },
-
       "HostedZone" : {
         "Value" : "bionano.bio."
       }
@@ -47,7 +41,7 @@
       "Type" : "AWS::ElastiCache::SubnetGroup",
       "Properties" : {
         "Description" : "Subnet group for the redis cluster",
-        "SubnetIds" : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SubnetIds" ] }
+        "SubnetIds" : {"Ref" : "SubNetIds"}
       }
     },
 
@@ -64,7 +58,7 @@
         "NumCacheClusters"            : 2,
         "Port"                        : 6379,
         "ReplicationGroupDescription" : {"Fn::Join" : [ "", [ { "Ref" : "BionanoEnvironment" }, " CCC redis cluster"] ]},
-        "SecurityGroupIds"            : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SecurityGroupIds" ] }
+        "SecurityGroupIds"            : {"Ref" : "SecGroupIds"}
       }
     },
 

--- a/etc/bionano/aws/cloudformation/redis/cf-ccc-redis.json
+++ b/etc/bionano/aws/cloudformation/redis/cf-ccc-redis.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
-  "Description": "CCC redis cluster. Custom to bionano infrastructure",
+  "Description": "(v1.0.1) CCC redis cluster. Custom to bionano infrastructure",
 
   "Parameters": {
     "BionanoEnvironment": {
@@ -20,16 +20,21 @@
 
  "Mappings" : {
     "Settings": {
-      "SubnetIds" : {
-        "dev" : ["subnet-a415dbd2", "subnet-522f9a36"],
-        "qa" : ["subnet-698bab1f", "subnet-fca680c1"],
-        "prod" : ["subnet-feae88c3", "subnet-6b98b81d"]
-      },
-      "SecurityGroupIds" : {
-        "dev" : ["sg-ab9292cc"],
-        "qa" : ["sg-fd5efb86"],
-        "prod" : ["sg-87389dfc"]
-      },
+      "dev" : {
+                "SubnetIds"        : ["subnet-a415dbd2", "subnet-522f9a36"], 
+                "SecurityGroupIds" : ["sg-ab9292cc"]
+              },
+
+      "qa" : {
+                "SubnetIds"        : ["subnet-698bab1f", "subnet-fca680c1"],
+                "SecurityGroupIds" : ["sg-fd5efb86"]
+              },
+
+      "prod" : {
+                "SubnetIds"        : ["subnet-feae88c3", "subnet-6b98b81d"], 
+                "SecurityGroupIds" : ["sg-87389dfc"]
+              },
+
       "HostedZone" : {
         "Value" : "bionano.bio."
       }
@@ -42,7 +47,7 @@
       "Type" : "AWS::ElastiCache::SubnetGroup",
       "Properties" : {
         "Description" : "Subnet group for the redis cluster",
-        "SubnetIds" : {"Fn::FindInMap" : [ "Settings", "SubnetIds", { "Ref" : "BionanoEnvironment" } ] }
+        "SubnetIds" : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SubnetIds" ] }
       }
     },
 
@@ -59,7 +64,7 @@
         "NumCacheClusters"            : 2,
         "Port"                        : 6379,
         "ReplicationGroupDescription" : {"Fn::Join" : [ "", [ { "Ref" : "BionanoEnvironment" }, " CCC redis cluster"] ]},
-        "SecurityGroupIds"            : {"Fn::FindInMap" : [ "Settings", "SecurityGroupIds", { "Ref" : "BionanoEnvironment" } ] }
+        "SecurityGroupIds"            : {"Fn::FindInMap" : [ "Settings", { "Ref" : "BionanoEnvironment" }, "SecurityGroupIds" ] }
       }
     },
 
@@ -69,7 +74,7 @@
       "Properties" : {
         "HostedZoneName" : {"Fn::FindInMap" : [ "Settings", "HostedZone", "Value" ] },
         "Comment" : "DNS entry for CCC redis cache",
-        "Name" : { "Fn::Join" : [ ".", ["redis", { "Ref" : "BionanoEnvironment" }, "bionano.bio."]]},
+        "Name" : { "Fn::Join" : [ ".", ["redis-ccc", { "Ref" : "BionanoEnvironment" }, "bionano.bio."]]},
         "Type" : "CNAME",
         "TTL" : "30",
         "ResourceRecords" : [ { "Fn::GetAtt" : [ "RedisCluster", "PrimaryEndPoint.Address" ] } ]

--- a/etc/bionano/aws/cloudformation/servers/aws-ccc-cloudformation.json
+++ b/etc/bionano/aws/cloudformation/servers/aws-ccc-cloudformation.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Create a Cloud-Compute-Cannon stack with AWS CloudFormation ",
+  "Description": "(v1.0.0) Create a Cloud-Compute-Cannon stack with AWS CloudFormation ",
   "Parameters": {
     "KeyName": {
       "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instances",

--- a/etc/bionano/aws/cloudformation/servers/generic-aws-ccc-cloudformation.json
+++ b/etc/bionano/aws/cloudformation/servers/generic-aws-ccc-cloudformation.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Create a Cloud-Compute-Cannon stack with AWS CloudFormation ",
+  "Description": "(v1.0.0) Create a Cloud-Compute-Cannon stack with AWS CloudFormation ",
   "Parameters": {
     "KeyName": {
       "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instances",

--- a/etc/bionano/aws/docker/docker-compose-aws.yml
+++ b/etc/bionano/aws/docker/docker-compose-aws.yml
@@ -12,7 +12,7 @@ services:
       - "9000:9000"
     environment:
       PORT: "9000"
-      REDIS_HOST: "redis.${BNR_ENVIRONMENT}.bionano.bio"
+      REDIS_HOST: "redis-ccc.${BNR_ENVIRONMENT}.bionano.bio"
       CONFIG_PATH: "/app/config/ccc.yml"
       CLIENT_DEPLOYMENT: "true"
       FLUENT_PORT: "24226"
@@ -31,6 +31,6 @@ services:
     image: "docker.io/dionjwa/bull-ui-server:1.0.1"
     environment:
       PORT: "9002"
-      REDIS_HOST: "redis.${BNR_ENVIRONMENT}.bionano.bio"
+      REDIS_HOST: "redis-ccc.${BNR_ENVIRONMENT}.bionano.bio"
     ports:
       - "9002:9002"


### PR DESCRIPTION
For easier checking and consistency with other scripts, I moved all Settings tied to an environment into the same json blocks.

Changed lambda tag logic to check both `app` and `environment`. These values are more defined and consistent than the `stack` tag. This should avoid potential future bugs.

Changed expected redis server name to avoid collisions with other redis clusters. 

Added rudimentary version tracking the Cf templates. Version is placed in beginning of comment for easy viewing in Cf console, comments.  